### PR TITLE
Don't mask trailing underscore in invalid float

### DIFF
--- a/tests/invalid/float/exp-trailing-us.toml
+++ b/tests/invalid/float/exp-trailing-us.toml
@@ -1,1 +1,1 @@
-exp-trailing-us = 1e_23_
+exp-trailing-us = 1e23_


### PR DESCRIPTION
A parser that fails to detect an invalid trailing underscore in a float may still pass the test if it detects the invalid leading underscore, which is extraneous in this test.