### PR TITLE
Use consistent representation for infinity

### DIFF
--- a/tests/valid/spec/float-2.json
+++ b/tests/valid/spec/float-2.json
@@ -1,15 +1,15 @@
 {
   "sf1": {
     "type": "float",
-    "value": "+Inf"
+    "value": "+inf"
   },
   "sf2": {
     "type": "float",
-    "value": "+Inf"
+    "value": "+inf"
   },
   "sf3": {
     "type": "float",
-    "value": "-Inf"
+    "value": "-inf"
   },
   "sf4": {
     "type": "float",


### PR DESCRIPTION
`valid/spec/float-2.json`, which is new in toml-test 1.4.0, caused issues with my test generator because it used `"Inf"` to represent the value `infinity` whereas all other valid tests follow the TOML representation and use `"inf"`. This PR changes the test to be consistent with all the others.