### PR TITLE
Update valid comment characters in toml v1.1.0

### DIFF
--- a/tests/files-toml-1.1.0
+++ b/tests/files-toml-1.1.0
@@ -44,11 +44,8 @@ invalid/control/bare-formfeed.toml
 invalid/control/bare-null.toml
 invalid/control/bare-vertical-tab.toml
 invalid/control/comment-cr.toml
-invalid/control/comment-del.toml
 invalid/control/comment-ff.toml
-invalid/control/comment-lf.toml
 invalid/control/comment-null.toml
-invalid/control/comment-us.toml
 invalid/control/multi-cr.toml
 invalid/control/multi-del.toml
 invalid/control/multi-lf.toml


### PR DESCRIPTION
Hi,

First of all, thank you for maintaining this repository and updating it so frequently. This repository is really helpful for identifying bugs in the parser/serializer and for understanding and explaining the specifications.

Recently, I noticed that some test cases are outdated in v1.1.0.

After the commit [ab74958](https://github.com/toml-lang/toml/commit/ab7495887ccd0f567d8a220e1a5ab0ca6fdbd16f), TOML allows most control characters except for `0x00`, `0x0A`, `0x0B`, `0x0C`, and `0x0D`.

Thus, although the following cases are invalid in TOML v1.0.0, they become valid after TOML v1.1.0:

- `comment_del.toml`: `0x7f` (DEL)
- `comment-lf.toml`: `0x10` (DLE)
- `comment-us.toml`: `0x1f` (US)

These characters are also included in `allowed-comment-char` defined in `toml.abnf` at the current commit in toml-lang/toml.

https://github.com/toml-lang/toml/blob/main/toml.abnf#L40-L43

So I removed those files from the list of invalid test cases defined in `tests/files-toml-1.1.0`.

Please check it whenever you have time.
Thank you.
