### PR TITLE
Add test for floats with leading zeroes on the fractional part.

### DIFF
--- a/tests/valid/float/float.json
+++ b/tests/valid/float/float.json
@@ -1,6 +1,7 @@
 {
-    "negpi":        {"type": "float", "value": "-3.14"},
-    "pi":           {"type": "float", "value": "3.14"},
-    "pospi":        {"type": "float", "value": "3.14"},
-    "zero-intpart": {"type": "float", "value": "0.123"}
+    "negpi":                   {"type": "float", "value": "-3.14"},
+    "pi":                      {"type": "float", "value": "3.14"},
+    "pospi":                   {"type": "float", "value": "3.14"},
+    "zero-intpart":            {"type": "float", "value": "0.123"},
+    "leading-zero-fractional": {"type": "float", "value": "0.0123"}
 }

--- a/tests/valid/float/float.toml
+++ b/tests/valid/float/float.toml
@@ -2,3 +2,4 @@ pi = 3.14
 pospi = +3.14
 negpi = -3.14
 zero-intpart = 0.123
+leading-zero-fractional = 0.0123


### PR DESCRIPTION
Ada-toml erroneously parses 0.0123 as 0.123 due to parsing the integer and fractional part as integers and then combining them. It's easy to see how other libraries could make the same mistake, therefore I think this would be a useful test-case to add.