### PR TITLE
Update valid bare key in toml v1.1.0

### DIFF
--- a/tests/files-toml-1.1.0
+++ b/tests/files-toml-1.1.0
@@ -223,7 +223,6 @@ invalid/key/quoted-unclosed-1.toml
 invalid/key/quoted-unclosed-2.toml
 invalid/key/single-open-bracket.toml
 invalid/key/space.toml
-invalid/key/special-character.toml
 invalid/key/start-bracket.toml
 invalid/key/start-dot.toml
 invalid/key/two-equals-1.toml


### PR DESCRIPTION
Hello.
I have always found this repository very helpful for testing parser behavior. Since toml v1.1.0 allows Unicode characters in bare keys, the following test case is now valid:

- special-character.toml

https://github.com/toml-lang/toml/blob/78fcf9dd7eab7acfbaf147c684b649477e7bdd9c/toml.abnf#L55-L64

I've removed this file from the list of invalid test cases defined in `tests/files-toml-1.1.0`.
Please check when you have time.