### PR TITLE
Use Go 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,11 @@ jobs:
       - uses: 'dominikh/staticcheck-action@v1'
 
   test:
-    strategy:
-      matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        go: ['1.19.x', '1.27.x']
+    strategy: {matrix: {os: ['ubuntu-latest', 'macos-latest', 'windows-latest']}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: 'actions/checkout@v6'
       - uses: 'actions/setup-go@v6'
-        with:
-          go-version: ${{ matrix.go }}
+        with: {go-version: '1.27.x'}
       - run:  'go install ./cmd/toml-test'
       - run:  'go test -race ./...'

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/toml-lang/toml-test/v2
 
-go 1.19
+go 1.27.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	zgo.at/jfmt v0.0.0-20250703165133-d1b6c356823b
+	zgo.at/jfmt v0.0.0-20260825153922-373911f68bf8
 	zgo.at/zli v0.0.0-20251226224229-7bb9a5cf3265
 )
 
@@ -12,5 +12,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	zgo.at/runewidth v0.1.0 // indirect
 	zgo.at/termtext v1.5.0 // indirect
-	zgo.at/zstd v0.0.0-20240531161000-9840c0c39ff5 // indirect
+	zgo.at/zstd v0.0.0-20260819203842-7567984d0ee9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,13 +2,13 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-zgo.at/jfmt v0.0.0-20250703165133-d1b6c356823b h1:uLkobfvdfHxVdBESRikiAbDRo6R0PZ0PjAn4jJFTwHI=
-zgo.at/jfmt v0.0.0-20250703165133-d1b6c356823b/go.mod h1:g2hlv4nhSZZuigOPEzsWJzgz9qa5/FJ06F0nirLGeCk=
+zgo.at/jfmt v0.0.0-20260825153922-373911f68bf8 h1:Qh/w9v+c86lRkwPlTKVoBEHywfSVLC3C+axtzyD8/yU=
+zgo.at/jfmt v0.0.0-20260825153922-373911f68bf8/go.mod h1:H7iiCvuNk5PZGwYnaalKQA6LuyeS6AWB3d8sT+YH9Ao=
 zgo.at/runewidth v0.1.0 h1:ED4PzJpYJlZMDEkoz+iPKjb5NrwbKnWPXDMJlNlfk9g=
 zgo.at/runewidth v0.1.0/go.mod h1:Ugl6FGPF5Ib/NRu2UAV2wVthEgYfEz51Bu/uyNbWZSw=
 zgo.at/termtext v1.5.0 h1:4p9GVUDYUR8oWvpxOZsO5ZrNSkA99bp8gXNKxKj+Kl0=
 zgo.at/termtext v1.5.0/go.mod h1:AcdAAiydkqSFadljJaEj9jv7bpyJxfQqGtPWyZCLenQ=
 zgo.at/zli v0.0.0-20251226224229-7bb9a5cf3265 h1:lF6LBMPq3zp1y84toTcZNkeRHx1ioK3Kz0CLC7GbUjU=
 zgo.at/zli v0.0.0-20251226224229-7bb9a5cf3265/go.mod h1:0jjx+AGEkWOOQ0NtzbMnpko+H2G+aTg8mfCKqoc/BuA=
-zgo.at/zstd v0.0.0-20240531161000-9840c0c39ff5 h1:tCJs56IMbX30f4wRkK9zr+Uxu9yiUexE88AkOFgZ+KI=
-zgo.at/zstd v0.0.0-20240531161000-9840c0c39ff5/go.mod h1:o/Q8+EtSahHnfkbB3t8wXE0FnoDTmJ0sBDlzezv9XeM=
+zgo.at/zstd v0.0.0-20260819203842-7567984d0ee9 h1:oaWpzu6FII4jAo/2lxvbAcVFcrJmxmOiGaKYeAikAdw=
+zgo.at/zstd v0.0.0-20260819203842-7567984d0ee9/go.mod h1:5vR5jYems3c7xfd8nHny5qMh67gbZwl8IockSF4pDSI=

--- a/json.go
+++ b/json.go
@@ -85,7 +85,7 @@ func (r Test) cmpJSONArrays(want, have any) Test {
 			"  Your encoder: %d",
 			r.Key, len(wantSlice), len(haveSlice))
 	}
-	for i := 0; i < len(wantSlice); i++ {
+	for i := range wantSlice {
 		if sub := r.CompareJSON(wantSlice[i], haveSlice[i]); sub.Failed() {
 			return sub
 		}

--- a/tests/valid/spec-1.0.0/array-0.json
+++ b/tests/valid/spec-1.0.0/array-0.json
@@ -5,7 +5,7 @@
         {"type": "string", "value": "green"}
     ],
     "contributors": [
-        {"type": "string", "value": "Foo Bar \u003cfoo@example.com\u003e"},
+        {"type": "string", "value": "Foo Bar <foo@example.com>"},
         {
             "email": {"type": "string", "value": "bazqux@example.com"},
             "name":  {"type": "string", "value": "Baz Qux"},

--- a/tests/valid/spec-1.0.0/string-5.json
+++ b/tests/valid/spec-1.0.0/string-5.json
@@ -1,6 +1,6 @@
 {
     "quoted":   {"type": "string", "value": "Tom \"Dubs\" Preston-Werner"},
-    "regex":    {"type": "string", "value": "\u003c\\i\\c*\\s*\u003e"},
+    "regex":    {"type": "string", "value": "<\\i\\c*\\s*>"},
     "winpath":  {"type": "string", "value": "C:\\Users\\nodejs\\templates"},
     "winpath2": {"type": "string", "value": "\\\\ServerX\\admin$\\system32\\"}
 }

--- a/tests/valid/spec-1.1.0/common-17.json
+++ b/tests/valid/spec-1.1.0/common-17.json
@@ -1,6 +1,6 @@
 {
     "quoted":   {"type": "string", "value": "Tom \"Dubs\" Preston-Werner"},
-    "regex":    {"type": "string", "value": "\u003c\\i\\c*\\s*\u003e"},
+    "regex":    {"type": "string", "value": "<\\i\\c*\\s*>"},
     "winpath":  {"type": "string", "value": "C:\\Users\\nodejs\\templates"},
     "winpath2": {"type": "string", "value": "\\\\ServerX\\admin$\\system32\\"}
 }

--- a/tests/valid/spec-1.1.0/common-35.json
+++ b/tests/valid/spec-1.1.0/common-35.json
@@ -5,7 +5,7 @@
         {"type": "string", "value": "green"}
     ],
     "contributors": [
-        {"type": "string", "value": "Foo Bar \u003cfoo@example.com\u003e"},
+        {"type": "string", "value": "Foo Bar <foo@example.com>"},
         {
             "email": {"type": "string", "value": "bazqux@example.com"},
             "name":  {"type": "string", "value": "Baz Qux"},

--- a/toml.go
+++ b/toml.go
@@ -107,7 +107,7 @@ func (r Test) cmpTOMLArrays(want []any, have any) Test {
 			"  Your encoder: %[3]v (len=%[5]d)",
 			r.Key, want, haveSlice, len(want), len(haveSlice))
 	}
-	for i := 0; i < len(want); i++ {
+	for i := range want {
 		if sub := r.CompareTOML(want[i], haveSlice[i]); sub.Failed() {
 			return sub
 		}


### PR DESCRIPTION
I've always been very conservative in the Go version, toml-test is easy to compile/use on older systems. But since Go 1.21, the "go" command will automatically download and use newer Go versions as a dependency.

Debian 13 now has 1.24, Ubuntu 26.04 Go 1.23.

So it should be okay to just use the latest Go version (1.27), which should "just work".

Changes in JSON are because of changes in the upstream jfmt formatter.